### PR TITLE
Fill in request so that session and envrionment are sent to Errbit

### DIFF
--- a/src/main/java/net/anthavio/airbrake/AirbrakeNoticeBuilderUsingFilteredSystemProperties.java
+++ b/src/main/java/net/anthavio/airbrake/AirbrakeNoticeBuilderUsingFilteredSystemProperties.java
@@ -15,14 +15,13 @@
  */
 package net.anthavio.airbrake;
 
-import java.util.LinkedList;
-import java.util.Map;
-
-import org.slf4j.MDC;
-
 import airbrake.AirbrakeNoticeBuilder;
 import airbrake.Backtrace;
 import airbrake.BacktraceLine;
+import org.slf4j.MDC;
+
+import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * Original airbrake.AirbrakeNoticeBuilderUsingFilteredSystemProperties has hardcoded org.apache.log4j.MDC usage
@@ -49,6 +48,7 @@ public class AirbrakeNoticeBuilderUsingFilteredSystemProperties extends Airbrake
 		addMDCToSession();
 		standardEnvironmentFilters();
 		ec2EnvironmentFilters();
+		setRequest("http://localhost", "");
 	}
 
 	public AirbrakeNoticeBuilderUsingFilteredSystemProperties(final String apiKey, final Backtrace backtraceBuilder,
@@ -59,6 +59,7 @@ public class AirbrakeNoticeBuilderUsingFilteredSystemProperties extends Airbrake
 		addMDCToSession();
 		standardEnvironmentFilters();
 		ec2EnvironmentFilters();
+		setRequest("http://localhost", "");
 	}
 
 	private void addMDCToSession() {

--- a/src/test/java/net/anthavio/airbrake/AirbrakeLogbackAppenderTest.java
+++ b/src/test/java/net/anthavio/airbrake/AirbrakeLogbackAppenderTest.java
@@ -15,10 +15,13 @@
  */
 package net.anthavio.airbrake;
 
-import java.util.List;
-
+import airbrake.AirbrakeNotice;
+import airbrake.AirbrakeNotifier;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.filter.ThresholdFilter;
+import ch.qos.logback.core.status.Status;
 import net.anthavio.airbrake.AirbrakeLogbackAppender.Notify;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -28,12 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
-import airbrake.AirbrakeNotice;
-import airbrake.AirbrakeNotifier;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.filter.ThresholdFilter;
-import ch.qos.logback.core.status.Status;
+import java.util.List;
 
 /**
  * 
@@ -98,8 +96,8 @@ public class AirbrakeLogbackAppenderTest {
         Assertions.assertThat(notice.env()).isEqualTo(appender.getEnv());
         Assertions.assertThat(notice.apiKey()).isEqualTo("whatever");
 
-        Assertions.assertThat(notice.component()).isNull();
-        Assertions.assertThat(notice.projectRoot()).isNull();
+        Assertions.assertThat(notice.component()).isNullOrEmpty();
+        Assertions.assertThat(notice.projectRoot()).isNullOrEmpty();
     }
 
     @Test


### PR DESCRIPTION
In the existing implementation together with airbreak-java 2.2.8, there is no way that the session and environment tabs in Errbit are filled in. While airbrake-logback does fill those in on the notice, airbreak-java only includes them in the Notice XML if the request is present.

This pull request fills in the request with dummy parameters (skipping otherwise having to make assumptions about one's application stack, like using Servlets or JAX-RS, etc) so that the session gets filled in with info from the MDC (still in a bit of a weird format IMO, but I will open another PR for that) and environment (All system properties) 

Maintainer: Please release the updated jar ASAP on Maven central if at all possible. Thanks!